### PR TITLE
Added setting to exclude more item types

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -11,6 +11,10 @@
     "MISSING_ITEM": "Missing Item",
     "MISSING_ITEM_DESCRIPTION": "This Spell's original item could not be found. Maybe it was deleted?",
     "WARN_ALSO_DELETE": "This will also delete the Spell from the Actor. Are you certain you want to delete the embedded spell?",
-    "QUERY_ALSO_DELETE": "Would you also like to delete the spells from that item?"
+    "QUERY_ALSO_DELETE": "Would you also like to delete the spells from that item?",
+    "SETTINGS": {
+      "ITEM_EXCLUSION.NAME": "Exclude More Item Types",
+      "ITEM_EXCLUSION.HINT": "Remove the spells tab from classes, subclasses, backgrounds, and feature type items, not just spell type items."
+    }
   }
 }

--- a/scripts/classes/item-sheet.js
+++ b/scripts/classes/item-sheet.js
@@ -2,6 +2,7 @@
 import { ItemsWithSpells5e } from '../items-with-spells-5e.js';
 import { ItemsWithSpells5eItemSpellOverrides } from './item-spell-overrides.js';
 import { ItemsWithSpells5eItem } from './item.js';
+import { EXTRA_EXCLUDED_TYPES } from './settings.mjs';
 
 /**
  * A class made to make managing the operations for an Item sheet easier.
@@ -28,6 +29,8 @@ export class ItemsWithSpells5eItemSheet {
       if (app.item.type === 'spell') {
         return;
       }
+      const exclude = game.settings.get("items-with-spells-5e", "itemTypeExclusion");
+      if(exclude && EXTRA_EXCLUDED_TYPES.includes(app.item.type)) return;
 
       ItemsWithSpells5e.log(false, {
         instances: this.instances,

--- a/scripts/classes/settings.mjs
+++ b/scripts/classes/settings.mjs
@@ -1,0 +1,19 @@
+export const EXTRA_EXCLUDED_TYPES = [
+  "class",
+  "subclass",
+  "feat",
+  "background",
+  "race"
+];
+
+export function _registerSettings() {
+  game.settings.register("items-with-spells-5e", "itemTypeExclusion", {
+    name: "items-with-spells-5e.SETTINGS.ITEM_EXCLUSION.NAME",
+    hint: "items-with-spells-5e.SETTINGS.ITEM_EXCLUSION.HINT",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+    requiresReload: true
+  });
+}

--- a/scripts/items-with-spells-5e.js
+++ b/scripts/items-with-spells-5e.js
@@ -2,6 +2,7 @@
 import { ItemsWithSpells5eActorSheet } from './classes/actor-sheet.js';
 import { ItemsWithSpells5eActor } from './classes/actor.js';
 import { ItemsWithSpells5eItemSheet } from './classes/item-sheet.js';
+import { _registerSettings } from './classes/settings.mjs';
 
 export class ItemsWithSpells5e {
   static API = {};
@@ -51,6 +52,8 @@ Hooks.once('init', () => {
 
   ItemsWithSpells5eActorSheet.init();
 });
+
+Hooks.once("setup", _registerSettings);
 
 ItemsWithSpells5eItemSheet.init();
 ItemsWithSpells5eActor.init();


### PR DESCRIPTION
Adds a single setting (default false so as not to disrupt anyone updating unknowingly) that when enabled prevents the Spells tab from appearing on classes, subclasses, backgrounds, and features.
Included 'race' as well preemptively.